### PR TITLE
Adds local tracking of opened previews

### DIFF
--- a/src/label_view.js
+++ b/src/label_view.js
@@ -1,38 +1,70 @@
 chrome.extension.sendMessage({}, function(response) {
+ var pluginState = window.localStorage;
+
  var readyStateCheckInterval = setInterval(function() {
  if (document.readyState === "complete") {
     clearInterval(readyStateCheckInterval);
 
-    $.fn.toggleClick = function() {
-        var methods = arguments;    // Store the passed arguments for future reference
-        var count = methods.length; // Cache the number of methods 
+    var preview_id; // globally stores which 'preview' button was last clicked
+    var preview_open = false; // globally stores if preveiw window is open
+    
+    function strBool(input){
+        /* 
+            converts string "true"/"false"
+            to bool
+        */
+        if(input === "true")
+            return true;
+        return false;
+    }
 
-        // Use return this to maintain jQuery chainability
-        // For each element you bind to
-        return this.each(function(i, item){
-            // Create a local counter for that element
-            var index = 0;
+    function toggleHistorybox(target, state){
+        target.attr('class', "follow-unfollow historybox");
+        if(state)
+            $(target).attr('class', "follow-unfollow historybox following");
+        return target
+    }
 
-            // Bind a click handler to that element
-            $(item).on('click', function() {
-                // That when called will apply the 'index'th method to that element
-                // the index % count means that we constrain our iterator between 0
-                // and (count-1)
-                return methods[index++ % count].apply(this, arguments);
-            });
-        });
-    };
-
+    function boxclick(event){
+        /*
+            tracks boxclicks to set pluginState for 'id'
+        */       
+        // get ID // this may be a better place to store the ID
+        var $id = $(event.target).parents('div').attr('id');
+        var $boxstate = pluginState.getItem($id);
         
-    function fillframe(event, toggleval) {
+        // switch historybox look
+        $boxstate = !(strBool($boxstate))
+        toggleHistorybox($(event.target), $boxstate)
+        
+        // update state
+        pluginState.setItem($id, $boxstate);
+    }
+        
+    function fillframe(event) {
         $('.bclv-frame').html(''); // clear all iframes
 
         var $bclv = $(event.target).parents('.music-grid-item').find('.bclv-frame');
         var id = $bclv.attr('id');
-        
-        console.log(id);
 
-        if (toggleval) {
+        // determine if preview window needs to be open
+        if (preview_open == true && preview_id == id){
+            preview_open = false;    
+        }
+        else {
+            preview_id = id;
+            preview_open = true;
+        }
+
+        if (preview_open) {
+            // preview opened, store this action in localstorage 'history'
+            pluginState.setItem(id, true);
+
+            // set checkbox to clicked
+            $checkbox = $(event.target).parents(`[id='${id}']`).find('.historybox');
+            $checkbox = toggleHistorybox($checkbox, true);
+
+            // fill frame
             var url = 'https://bandcamp.com/EmbeddedPlayer/album='+id;
             url = url + '/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=true/artwork=none/transparent=true/"';
 
@@ -42,58 +74,69 @@ chrome.extension.sendMessage({}, function(response) {
         }
     }
 
-    // Append .open-iframe links (also use for iFrames)
+    // helper function for creating preview button
+    function generatePreview(id) {
+        // check if preview button has been pressed
+        if(pluginState.getItem(id) === null) {
+            pluginState.setItem(id, false);
+        }
+
+        $parent_div = $('<div>');
+        $parent_div.attr('id', id);
+
+        $button = $('<button>');
+        $button.attr('type', "button");
+        $button.attr('class', "follow-unfollow open-iframe");
+        $button.attr('style', "width: 90%");
+
+        $preview = $('<div>').html("Preview");
+        $button.append($preview);
+        
+        $bclvframe = $('<div>');
+        $bclvframe.attr('class', "bclv-frame").attr('id', id);
+
+        // add checkbox with stores history of clicks
+        $checkbox = $('<button>');
+        $checkbox.attr('style', "margin: 0px 0px 0px 5px; width: 28px; height: 28px; position: absolute;");
+        
+        $boxstate = strBool(pluginState.getItem(id));
+        $checkbox = toggleHistorybox($checkbox, $boxstate);
+
+        $parent_div.append($button);
+        $parent_div.append($checkbox);
+        $parent_div.append($bclvframe);
+
+        return $parent_div
+    }
+
+    // iterate over page to get album IDs and append buttons with value
     $('li[data-item-id]').each(function(index, item){
         var id = $(item).closest('li').attr('data-item-id');
         if (id.split("-")[0] == "album"){
             id = id.split("-")[1];
         }
-        //console.log(id);
-        $parent_div = $('<div>');
-        $button = $('<button>');
-        $button.attr('type', "button");
-        $button.attr('class', "follow-unfollow open-iframe");
 
-        $preview = $('<div>').html("Preview");
-        $button.append($preview);
-        
-        $bclvframe = $('<div>');
-        $bclvframe.attr('class', "bclv-frame").attr('id', id);
-
-        $parent_div.append($button)
-        $parent_div.append($bclvframe);
-        $(item).append($parent_div);
+        $preview_element = generatePreview(id);
+        $(item).append($preview_element);
     });
 
-    // Append .open-iframe links (also use for iFrames)
+    // iterate over page to get album IDs and append buttons with value
     $('li[data-tralbumid][data-tralbumtype="a"]').each(function(index, item){
         var id = $(item).attr('data-tralbumid');
         
-        // console.log(id);
-        $parent_div = $('<div>')
-        $button = $('<button>');
-        $button.attr('type', "button");
-        $button.attr('class', "compound-button open-iframe");
-
-        $preview = $('<div>').html("Preview");
-        $button.append($preview);
-        
-        $bclvframe = $('<div>');
-        $bclvframe.attr('class', "bclv-frame").attr('id', id);
-        // $button.append($bclvframe);
-        $parent_div.append($button)
-        $parent_div.append($bclvframe);
-        $(item).append($parent_div);
-        
-        // $(item).append($button);
+        $preview_element = generatePreview(id);
+        $(item).append($preview_element);
     });
 
-    $('.open-iframe').toggleClick(
+    $('.open-iframe').on('click', 
         function(event){
-            fillframe(event, true);
-        },
+            fillframe(event);
+        }
+    );
+
+    $('.historybox').on('click', 
         function(event){
-            fillframe(event, false);
+            boxclick(event);
         }
     );
 


### PR DESCRIPTION
Previously, there was not way to know if an album had been previewed.

This commit adds the ability to track opened previews. This tracking is done with `window.localStorage`. The history is tracked with a clickable element to the right of the preview button. This clickable element will change state (previewed, represented by a color change) when a preview is initiated. Additionally, the preview state can be overridden by directly clicking this element.