### PR TITLE
Fix text in icon hover content

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
   },
   "browser_action": {
     "default_icon": "icons/icon19.png",
-    "default_title": "browser action",
+    "default_title": "Bandcamp Label View",
     "default_popup": "src/browser_action/browser_action.html"
   },
   "permissions": [

--- a/src/browser_action/browser_action.html
+++ b/src/browser_action/browser_action.html
@@ -13,5 +13,5 @@
 
 <div id="mainPopup">
 <h1>Bandcamp Label View</h1>
-<p>Use this extension on Bandcamp label pages to add preview to album links. This lets you move through a labels catalogue without having to open a lot of tabs!</p>
+<p>Use this extension on Bandcamp label pages to add preview to album links. This lets you move through a label's catalogue without having to open a lot of tabs!</p>
 </div>


### PR DESCRIPTION
2 small changes:

- Change "browser action" text to the extension name (see image below)
- Resolve #13 

<img width="186" alt="Screen Shot 2019-09-25 at 11 16 18 AM" src="https://user-images.githubusercontent.com/1182187/65628320-16a47880-df86-11e9-9786-48c47617c999.png">
